### PR TITLE
Result should include envelope

### DIFF
--- a/lib/stubTransport.js
+++ b/lib/stubTransport.js
@@ -34,6 +34,7 @@ module.exports = {
         let info = {
           messageId,
           response,
+          envelope: envelope,
           from: envelope.from,
           to: envelope.to,
           content: mail.message.content,

--- a/test/stubTransport.spec.js
+++ b/test/stubTransport.spec.js
@@ -28,6 +28,7 @@ test('it sends a message', async () => {
   })
 
   mail.messageId.should.not.be.null
+  mail.envelope.should.not.be.null
   mail.response.should.be.instanceOf(Buffer)
   mail.from.should.eq(exampleMail.from)
   mail.to[0].should.eq(exampleMail.to)


### PR DESCRIPTION
Node Mailer recommends that transports should send back the
envelope as a property of the result. While it is not required,
exposing this property would be helpful.