### PR TITLE
Adds an error transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ let mail = await transport.sendMail({
 })
 ```
 
+For testing purposes, there is also a transport called `errorTransport`, where
+the transport throws an error during execution, to help with testing the
+robustness of your mail service logic.
+
 We've also included a testing utility class, called `interactsWithMail`. You can use it in your tests like this:
 
 ```javascript

--- a/lib/errorTransport.js
+++ b/lib/errorTransport.js
@@ -1,0 +1,18 @@
+/**
+ * A transport that errors out, for mail service tests
+ *
+ * @type {{name: string, version: string, send: Function, error: any}}
+ */
+module.exports = {
+  name: 'ErrorTransport',
+  version: '1.0.0',
+
+  error: new Error('The transport has an error, by design'),
+
+  send: function (mail, callback) {
+    const self = this
+    setImmediate(() => {
+      return callback(self.error)
+    })
+  }
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,9 @@
+const errorTransport = require('./errorTransport')
 const interactsWithMail = require('./interactsWithMail')
 const stubTransport = require('./stubTransport')
 
 module.exports = {
+  errorTransport,
   interactsWithMail,
   stubTransport
 }

--- a/test/errorTransport.spec.js
+++ b/test/errorTransport.spec.js
@@ -1,0 +1,36 @@
+const test = require('ava')
+require('chai').should()
+import { errorTransport } from '../lib/main'
+import nodeMailer from 'nodemailer'
+
+const exampleMail = {
+  to: 'john@domain.com',
+  from: 'jimmy@domain.com',
+  subject: 'testing',
+  content: 'foo',
+  contentType: 'text/plain'
+}
+
+test('Nodemailer loads a correct transport', () => {
+  let transport = nodeMailer.createTransport(errorTransport)
+
+  transport.transporter.name.should.eq('ErrorTransport')
+  transport.transporter.send.should.be.instanceOf(Function)
+})
+
+test('it fails to send a message', async () => {
+  let transport = nodeMailer.createTransport(errorTransport)
+  let failed = null
+  try {
+    await transport.sendMail({
+      from: exampleMail.from,
+      to: exampleMail.to,
+      subject: exampleMail.subject,
+      text: exampleMail.content
+    })
+  } catch (transportError) {
+    failed = transportError
+  }
+
+  failed.should.not.be.null
+})


### PR DESCRIPTION
To help with building robust mail services, this extends the
stub library to offer an errorTransport implementation that
always throws an error instead of sending mail.