### PR TITLE
Change the content to be taken also from chunks

### DIFF
--- a/lib/stubTransport.js
+++ b/lib/stubTransport.js
@@ -31,13 +31,17 @@ module.exports = {
       setImmediate(() => {
         let messageId = (mail.message.getHeader('message-id')).replace(/[<>\s]/g, '')
         let response = Buffer.concat(chunks, chunkLength)
+        let contents = [mail.message.content];
+        for (chunk of mail.message.childNodes){
+            contents.push(chunk.content);
+        }
         let info = {
           messageId,
           response,
           envelope: envelope,
           from: envelope.from,
           to: envelope.to,
-          content: mail.message.content,
+          contents: contents,
           contentType: mail.message.contentType,
           subject: mail.message.getHeader('subject') || ''
         }


### PR DESCRIPTION
Currently the content is just taken from mail, it is possible for the email to be divided into chunks, in which case the content is in the child nodes. This patch is taking contents as a list from child nodes.