### PR TITLE
Change the content to be taken also from chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ const exampleMail = {
   from: 'jimmy@domain.com',
   subject: 'testing',
   content: 'foo',
+  contents: ['foo'],
   contentType: 'text/plain'
 }
 
@@ -56,7 +57,8 @@ test('it retrieves the last message', () => {
   lastMail.to.should.eq('john@domain.com')
   lastMail.from.should.eq('jimmy@domain.com')
   lastMail.subject.should.eq('testing')
-  lastMail.content.should.eq('foo')
+  lastMail.content.should.eq(['foo'])
+  lastMail.contents.should.eq(['foo'])
   lastMail.contentType.should.eq('text/plain')
 })
 ```
@@ -70,6 +72,7 @@ Accessible properties:
 - to
 - subject
 - content
+- contents
 - contentType
 
 ### `newMail (Object)`

--- a/lib/stubTransport.js
+++ b/lib/stubTransport.js
@@ -31,6 +31,10 @@ module.exports = {
       setImmediate(() => {
         let messageId = (mail.message.getHeader('message-id')).replace(/[<>\s]/g, '')
         let response = Buffer.concat(chunks, chunkLength)
+        let contents = [mail.message.content]
+        for (let chunk of mail.message.childNodes) {
+          contents.push(chunk.content)
+        }
         let info = {
           messageId,
           response,
@@ -38,6 +42,7 @@ module.exports = {
           from: envelope.from,
           to: envelope.to,
           content: mail.message.content,
+          contents: contents,
           contentType: mail.message.contentType,
           subject: mail.message.getHeader('subject') || ''
         }

--- a/test/stubTransport.spec.js
+++ b/test/stubTransport.spec.js
@@ -34,6 +34,8 @@ test('it sends a message', async () => {
   mail.to[0].should.eq(exampleMail.to)
   mail.subject.should.eq(exampleMail.subject)
   mail.content.should.eq(exampleMail.content)
+  mail.contents.length.should.eq(1)
+  mail.contents[0].should.eq(exampleMail.content)
   mail.contentType.should.eq(exampleMail.contentType)
 })
 
@@ -51,5 +53,7 @@ test('it falls back to an empty string for subject', async () => {
   mail.to[0].should.eq(exampleMail.to)
   mail.subject.should.eq('')
   mail.content.should.eq(exampleMail.content)
+  mail.contents.length.should.eq(1)
+  mail.contents[0].should.eq(exampleMail.content)
   mail.contentType.should.eq(exampleMail.contentType)
 })


### PR DESCRIPTION
Created additional "contents" field in case email is transported in chunks.
The content of all the chunks gets collected into "contents"  array.